### PR TITLE
Export duplicate records to Excel on duplicate detection

### DIFF
--- a/src/app/views/credit-info/form-upload/form-upload.component.ts
+++ b/src/app/views/credit-info/form-upload/form-upload.component.ts
@@ -4,7 +4,7 @@ import { MessageService, PrimeNGConfig } from 'primeng/api';
 import { forkJoin } from 'rxjs';
 import { CreditExcel } from 'src/app/core/models/data';
 import { City, CreditClassification, Institution, MannerPayment, Sector, TypeCollateral } from 'src/app/core/models/data-master';
-import { AuthenticationService } from 'src/app/core/services';
+import { AuthenticationService, FileExportService } from 'src/app/core/services';
 import { CreditService } from 'src/app/core/services/credit.service';
 import { read, utils, writeFile } from "xlsx";
 
@@ -47,6 +47,7 @@ export class FormUploadComponent {
     private router: Router,
     private route: ActivatedRoute,
     private authService: AuthenticationService,
+    private fileExportService: FileExportService,
   ) {
     this.columnsExcel = ['NameCreditGrantor', 'ElectNo', 'DateAcctOpened', 'DueDate', 'OrgBal', 'MonthlyPaymt', 'DateLastPaymt', 'Balance', 'CreditbySector', 'MannerofPaymt', 'Security', 'DescofCollateral', 'AssetClass', 'Guarantee Name', 'ElectNo (Guarantee)', 'DOB (Guarantee)', 'City (Guarantee)', 'EmpHist (Guarantee)'];
     this.columns = ['Credit Grantor', 'ID Number / TIN', 'Due Cate', 'Monthly Payment', 'Last Payment (Date)', 'Balance'];
@@ -436,6 +437,9 @@ export class FormUploadComponent {
         this.duplicatesDateLastPaymentAndBalance = response2.allDuplicates;
         this.showMissingMessages();
         this.showDuplicateMessages();
+        if (this.duplicatesDateLastPaymentAndBalance.length > 0) {
+          this.exportDuplicatesToExcel();
+        }
       },
       error: err => {
         this.isScanning = false;
@@ -445,6 +449,37 @@ export class FormUploadComponent {
         this.isScanning = false;
       }
     });
+  }
+
+  /**
+   * Exports the duplicate (LastPaymentDate + Balance) records to an Excel file.
+   *
+   * Flattens each record's nested objects (grantor, sector, guarantee, ...) into
+   * the same columns shown in the review table so the sheet is human-readable.
+   */
+  private exportDuplicatesToExcel(): void {
+    const rows = this.duplicatesDateLastPaymentAndBalance.map((item: any) => ({
+      'NameCreditGrantor': item.grantor?.name,
+      'ElectNo': item.idNumber,
+      'DateAcctOpened': item.accountCreationDate,
+      'DueDate': item.dueDate,
+      'OrgBal': item.originalBalance,
+      'MonthlyPaymt': item.monthlyPayment,
+      'DateLastPaymt': item.lastPaymentDate,
+      'Balance': item.balance,
+      'CreditbySector': item.sector?.name,
+      'MannerofPaymt': item.mannerOfPayment?.name,
+      'Security': item.security?.name,
+      'DescofCollateral': item.descriptionSecurity ?? 'N/A',
+      'AssetClass': item.assetClass?.name,
+      'Guarantee Name': item.guarantee?.fullName,
+      'ElectNo (Guarantee)': item.guarantee?.electoralNumber,
+      'DOB (Guarantee)': item.guarantee?.birthDate,
+      'City (Guarantee)': item.guarantee?.city?.name,
+      'EmpHist (Guarantee)': item.guarantee?.employmentHistory,
+    }));
+
+    this.fileExportService.exportToExcel(rows, 'CreditInfo_Duplicates');
   }
 
   /**

--- a/src/app/views/demographic/form-upload/form-upload.component.ts
+++ b/src/app/views/demographic/form-upload/form-upload.component.ts
@@ -4,7 +4,7 @@ import { MessageService, PrimeNGConfig } from 'primeng/api';
 import { DemographicExcel } from 'src/app/core/models/data';
 import { Beneficiary, City, MaritalStatus } from 'src/app/core/models/data-master';
 import { BeneficiaryType } from 'src/app/core/models/enum';
-import { DemographicService } from 'src/app/core/services';
+import { DemographicService, FileExportService } from 'src/app/core/services';
 import { read, utils, writeFile } from "xlsx";
 
 @Component({
@@ -40,6 +40,7 @@ export class FormUploadComponent {
     private config: PrimeNGConfig,
     private messageService: MessageService,
     private demographicService: DemographicService,
+    private fileExportService: FileExportService,
     private router: Router,
     private route: ActivatedRoute,
   ) {
@@ -319,6 +320,9 @@ export class FormUploadComponent {
       next: response => {
         this.duplicatesData = response;
         this.showDuplicateMessages();
+        if (this.duplicatesData.length > 0) {
+          this.exportDuplicatesToExcel();
+        }
       },
       error: err => {
         this.isScanning = false;
@@ -353,6 +357,27 @@ export class FormUploadComponent {
     }
 
     return duplicates;
+  }
+
+  /**
+   * Exports the database-matching duplicate records to an Excel file.
+   *
+   * Flattens each duplicate's nested objects (beneficiary, city) into the same
+   * columns shown in the review table so the sheet is human-readable.
+   */
+  private exportDuplicatesToExcel(): void {
+    const rows = this.duplicatesData.map((item: any) => ({
+      'Name': item.fullName,
+      'Electoral Nº/Taxpayer ID (TIN)': item.idNumber,
+      'Beneficiary': item.beneficiary?.name,
+      'Date of Birth': item.birthDate,
+      'Gender': item.gender,
+      'City - Address': `${item.address} - ${item.city?.name ?? ''}`,
+      'Employment History': item.employmentHistory,
+      'Telephone Nº': item.phoneNumber,
+    }));
+
+    this.fileExportService.exportToExcel(rows, 'Demographic_Duplicates');
   }
 
 


### PR DESCRIPTION
## What

When `checkJsonData` detects duplicates in the **Demographic** and **Credit-info** `form-upload` components, the duplicate rows are now auto-exported to an Excel file for offline review/sharing.

- **Demographic** — exports `duplicatesData` (records already matching the database) as `Demographic_Duplicates.xlsx`.
- **Credit-info** — exports `duplicatesDateLastPaymentAndBalance` as `CreditInfo_Duplicates.xlsx`.

## Why

Reviewers previously could only see conflicting rows inside the upload wizard's duplicate tabs. Exporting them lets users reconcile duplicates against their source spreadsheet outside the app before re-uploading.

## How

- Reuses the existing `FileExportService.exportToExcel()` (workbook creation, sheet-name truncation, compression) — injected into both component constructors.
- Each duplicate's nested objects (`beneficiary`, `city`, `grantor`, `guarantee`, `sector`, ...) are flattened into the same column headers shown in the review tables, so the sheet is human-readable instead of `[object Object]`.
- Export fires inside the `next` handler, only after the backend confirms duplicates (`length > 0`).

## Reviewer notes

- The export is **automatic** on every scan that finds duplicates. If a manual "Export Duplicates" button on the duplicates tab is preferred, the export methods just need to be made `public` and wired to a `p-button`.
- For Credit-info, the duplicate set hooked into is `duplicatesDateLastPaymentAndBalance` (its analog to Demographic's `duplicatesData`), not the missing-records set (`notFoundData`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)